### PR TITLE
Fix infinite loop when fetching item values and added foldables compatibility

### DIFF
--- a/Configuration/Settings.cs
+++ b/Configuration/Settings.cs
@@ -28,7 +28,8 @@ public static class Settings
     public static ConfigEntry<SortOptions> ItemType { get; set; }
     public static ConfigEntry<SortOptions> Weight { get; set; }
     public static ConfigEntry<SortOptions> TraderValue { get; set; }
-    public static ConfigEntry<SortOptions> MarketValue { get; set; }
+    // TODO: Flea market sorting not ready yet
+    // public static ConfigEntry<SortOptions> MarketValue { get; set; }
 
     public static void BackupSortOptions()
     {
@@ -39,7 +40,7 @@ public static class Settings
             { "ItemType", ItemType.Value },
             { "Weight", Weight.Value },
             { "Value", TraderValue.Value },
-            { "FleaValue", MarketValue.Value }
+            // TODO { "FleaValue", MarketValue.Value }
         };
     }
 
@@ -55,7 +56,7 @@ public static class Settings
         ItemType.Value = _backup["ItemType"];
         Weight.Value = _backup["Weight"];
         TraderValue.Value = _backup["Value"];
-        MarketValue.Value = _backup["FleaValue"];
+        // TODO MarketValue.Value = _backup["FleaValue"];
         _backup = null;
     }
 
@@ -99,8 +100,9 @@ public static class Settings
         Weight = config.Bind(SortingStrategySection, "Sort by item weight", SortOptions.None,
             new ConfigDescription("Sort by item weight", null, new ConfigurationManagerAttributes { Order = 47 }));
 
-        MarketValue = config.Bind(SortingStrategySection, "Sort by item flea market value", SortOptions.None,
-            new ConfigDescription("Sort by market value", null, new ConfigurationManagerAttributes { Order = 46 }));
+        // TODO: Flea market sorting not ready yet
+        // MarketValue = config.Bind(SortingStrategySection, "Sort by item flea market value", SortOptions.None,
+        //     new ConfigDescription("Sort by market value", null, new ConfigurationManagerAttributes { Order = 46 }));
 
         TraderValue = config.Bind(SortingStrategySection, "Sort by item trader value", SortOptions.None,
             new ConfigDescription("Sort by trader value", null, new ConfigurationManagerAttributes { Order = 45 }));
@@ -108,17 +110,16 @@ public static class Settings
 
     public static SortOptions GetSortOption(string typeName)
     {
-        var option = typeName switch
+        return typeName switch
         {
             "ContainerSize" => ContainerSize.Value,
             "CellSize" => CellSize.Value,
             "ItemType" => ItemType.Value,
             "Weight" => Weight.Value,
             "Value" => TraderValue.Value,
-            "FleaValue" => MarketValue.Value,
-            _ => throw new System.ArgumentException("Invalid sort type")
-        };
+            // TODO: "FleaValue" => MarketValue.Value,
 
-        return option;
+            _ => SortOptions.None
+        };
     }
 }

--- a/Configuration/Settings.cs
+++ b/Configuration/Settings.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using BepInEx.Configuration;
+using StashManagementHelper.Helpers;
 using StashManagementHelper.SortingStrategy;
 
 namespace StashManagementHelper.Configuration;
@@ -16,6 +17,7 @@ public static class Settings
 
     public static ConfigEntry<SortEnum> SortingStrategy { get; set; }
     public static ConfigEntry<bool> FoldItems { get; set; }
+    public static ConfigEntry<bool> FoldItemsWithContents { get; set; }
     public static ConfigEntry<bool> MergeItems { get; set; }
     public static ConfigEntry<bool> RotateItems { get; set; }
     public static ConfigEntry<bool> FlipSortDirection { get; set; }
@@ -75,17 +77,28 @@ public static class Settings
         FoldItems = config.Bind(SortingSection, "Fold items", true,
             new ConfigDescription("Fold items to save space.", null, new ConfigurationManagerAttributes { Order = 97 }));
 
+        // Only show if Foldables mod is detected
+        if (FoldablesCompatibility.IsFoldablesInstalled)
+        {
+            FoldItemsWithContents = config.Bind(SortingSection, "Fold containers with items inside", false,
+                new ConfigDescription(
+                    "When enabled, containers (backpacks, rigs) that have items inside them will be folded. " +
+                    "Disabled by default. (Foldables mod compatibility)",
+                    null,
+                    new ConfigurationManagerAttributes { Order = 96 }));
+        }
+
         MergeItems = config.Bind(SortingSection, "Merge items", true,
-            new ConfigDescription("Merge stacking items to save space.", null, new ConfigurationManagerAttributes { Order = 96 }));
+            new ConfigDescription("Merge stacking items to save space.", null, new ConfigurationManagerAttributes { Order = 95 }));
 
         RotateItems = config.Bind(SortingSection, "Rotate items", true,
-            new ConfigDescription("Rotate items for best fit.", null, new ConfigurationManagerAttributes { Order = 95 }));
+            new ConfigDescription("Rotate items for best fit.", null, new ConfigurationManagerAttributes { Order = 94 }));
 
         FlipSortDirection = config.Bind(SortingSection, "Flip sort direction", false,
-            new ConfigDescription("Start sorting from bottom up.", null, new ConfigurationManagerAttributes { Order = 94 }));
+            new ConfigDescription("Start sorting from bottom up.", null, new ConfigurationManagerAttributes { Order = 93 }));
 
         SkipRows = config.Bind(SortingSection, "Skip rows", 0,
-            new ConfigDescription("Skips the first # rows in stash.", new AcceptableValueRange<int>(0, 10), new ConfigurationManagerAttributes { Order = 93 }));
+            new ConfigDescription("Skips the first # rows in stash.", new AcceptableValueRange<int>(0, 10), new ConfigurationManagerAttributes { Order = 92 }));
 
         // Sorting strategy
         ContainerSize = config.Bind(SortingStrategySection, "Sort by container size", SortOptions.Enabled | SortOptions.Descending,

--- a/Helpers/FoldablesCompatibility.cs
+++ b/Helpers/FoldablesCompatibility.cs
@@ -1,0 +1,33 @@
+using BepInEx.Bootstrap;
+using BepInEx.Logging;
+
+namespace StashManagementHelper.Helpers;
+
+/// <summary>
+/// Helper class to detect and manage compatibility with the Foldables mod.
+/// https://github.com/ozen-m/SPT-Foldables
+/// </summary>
+public static class FoldablesCompatibility
+{
+    private const string FoldablesPluginGuid = "com.ozen.foldables";
+
+    /// <summary>
+    /// Gets whether the Foldables mod is currently installed and loaded.
+    /// </summary>
+    public static bool IsFoldablesInstalled { get; private set; }
+
+    /// <summary>
+    /// Initialize Foldables detection.
+    /// </summary>
+    /// <param name="logger">Logger instance for logging detection results.</param>
+    public static void Initialize(ManualLogSource logger)
+    {
+        IsFoldablesInstalled = Chainloader.PluginInfos.ContainsKey(FoldablesPluginGuid);
+
+        if (IsFoldablesInstalled)
+        {
+            logger.LogInfo($"Foldables mod detected ({FoldablesPluginGuid}).");
+        }
+    }
+}
+

--- a/Helpers/TraderExtensions.cs
+++ b/Helpers/TraderExtensions.cs
@@ -1,49 +1,78 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
 using EFT;
 using SPT.Reflection.Utils;
 
 namespace StashManagementHelper.Helpers;
 
-// Extension methods to fetch supply data and price from TraderClass
 public static class TraderExtensions
 {
-    private static ISession _session;
-
     private static readonly FieldInfo SupplyDataField = typeof(TraderClass).GetField("supplyData_0", BindingFlags.NonPublic | BindingFlags.Instance);
+    private static ISession _session;
+    private static List<TraderClass> _cachedTraders;
+    private static volatile bool _isUpdating;
+    private static DateTime _lastUpdate = DateTime.MinValue;
+
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(1);
 
     public static ISession Session => _session ??= ClientAppUtils.GetMainApp().GetClientBackEndSession();
 
+    /// <summary>
+    /// Cached list of traders.
+    /// </summary>
+    public static List<TraderClass> Traders => _cachedTraders ??= Session?.Traders?.Where(t => !t.Settings.AvailableInRaid).ToList() ?? [];
+
     public static SupplyData GetSupplyData(this TraderClass trader)
     {
-        return SupplyDataField != null ? SupplyDataField.GetValue(trader) as SupplyData : null;
+        return SupplyDataField?.GetValue(trader) as SupplyData;
     }
 
-    public static void SetSupplyData(this TraderClass trader, SupplyData data)
+    /// <summary>
+    /// Ensures supply data is fetched for all traders.
+    /// </summary>
+    public static void EnsureSupplyDataUpdated()
     {
-        if (SupplyDataField == null)
+        if (SupplyDataField == null || _isUpdating) return;
+        if (DateTime.UtcNow - _lastUpdate < CacheDuration) return;
+
+        var tradersNeedingData = Traders.Where(t => t.GetSupplyData() == null).ToList();
+        if (tradersNeedingData.Count == 0)
         {
-            ItemManager.Logger.LogWarning("SupplyData field not found on TraderClass; skipping SetSupplyData.");
+            _lastUpdate = DateTime.UtcNow;
             return;
         }
 
-        SupplyDataField.SetValue(trader, data);
+        _isUpdating = true;
+        Task.Run(() => UpdateAllAsync(tradersNeedingData))
+            .ContinueWith(_ =>
+            {
+                _isUpdating = false;
+                _lastUpdate = DateTime.UtcNow;
+            });
     }
 
-    public static async void UpdateSupplyData(this TraderClass trader)
+    private static async Task UpdateAllAsync(List<TraderClass> traders)
     {
-        if (SupplyDataField == null)
-        {
-            return;
-        }
+        var tasks = traders.Select(UpdateTraderAsync);
+        await Task.WhenAll(tasks);
+    }
 
-        var result = await Session.GetSupplyData(trader.Id);
-        if (result.Succeed)
+    private static async Task UpdateTraderAsync(TraderClass trader)
+    {
+        try
         {
-            trader.SetSupplyData(result.Value);
+            var result = await Session.GetSupplyData(trader.Id);
+            if (result.Succeed)
+            {
+                SupplyDataField.SetValue(trader, result.Value);
+            }
         }
-        else
+        catch (Exception ex)
         {
-            ItemManager.Logger.LogError("Failed to download supply data");
+            ItemManager.Logger.LogError($"Failed to update supply data for {trader.Id}: {ex.Message}");
         }
     }
 }

--- a/Patches/FindFreeSpacePatch.cs
+++ b/Patches/FindFreeSpacePatch.cs
@@ -1,12 +1,12 @@
-﻿using EFT.InventoryLogic;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using EFT.InventoryLogic;
 using HarmonyLib;
 using SPT.Reflection.Patching;
 using StashManagementHelper.Configuration;
 using StashManagementHelper.Helpers;
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace StashManagementHelper.Patches;
 

--- a/Patches/GridSortPanelContextPatch.cs
+++ b/Patches/GridSortPanelContextPatch.cs
@@ -197,7 +197,7 @@ namespace StashManagementHelper.Patches
             fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
             fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
 
-            //CreateMenuButton("Sort by Market Value", () => { SwapFlags("FleaValue"); DestroyCustomMenu(); }); //TODO
+            //CreateMenuButton("Sort by Market Value", () => { SwapFlags("FleaValue"); DestroyCustomMenu(); }); // TODO: Flea market sorting not ready yet
             CreateMenuButton("Sort by Trader Value", () => { SwapFlags("Value"); DestroyCustomMenu(); });
             CreateMenuButton("Sort by Item Weight", () => { SwapFlags("Weight"); DestroyCustomMenu(); });
 
@@ -384,7 +384,7 @@ namespace StashManagementHelper.Patches
             Settings.ItemType.Value = SortOptions.None;
             Settings.Weight.Value = (mode == "Weight") ? (SortOptions.Enabled | SortOptions.Descending) : SortOptions.None;
             Settings.TraderValue.Value = (mode == "Value") ? (SortOptions.Enabled | SortOptions.Descending) : SortOptions.None;
-            Settings.MarketValue.Value = (mode == "FleaValue") ? (SortOptions.Enabled | SortOptions.Descending) : SortOptions.None;
+            //Settings.MarketValue.Value = (mode == "FleaValue") ? (SortOptions.Enabled | SortOptions.Descending) : SortOptions.None;      // TODO: Flea market sorting not ready yet
 
             // Invoke the existing sort button
             _sortBtn.onClick.Invoke();

--- a/Patches/GridSortPanelContextPatch.cs
+++ b/Patches/GridSortPanelContextPatch.cs
@@ -1,10 +1,10 @@
+using System;
+using System.Linq;
+using System.Reflection;
 using HarmonyLib;
 using SPT.Reflection.Patching;
 using StashManagementHelper.Configuration;
 using StashManagementHelper.SortingStrategy;
-using System;
-using System.Linq;
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;

--- a/Patches/ItemListSortPatch.cs
+++ b/Patches/ItemListSortPatch.cs
@@ -1,12 +1,12 @@
-﻿using EFT.InventoryLogic;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using EFT.InventoryLogic;
 using HarmonyLib;
 using SPT.Reflection.Patching;
 using StashManagementHelper.Configuration;
 using StashManagementHelper.Helpers;
 using StashManagementHelper.SortingStrategy;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace StashManagementHelper.Patches;
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -6,11 +6,15 @@ using StashManagementHelper.Patches;
 namespace StashManagementHelper;
 
 [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+[BepInDependency("com.ozen.foldables", BepInDependency.DependencyFlags.SoftDependency)]
 public class Plugin : BaseUnityPlugin
 {
     private void Awake()
     {
         ItemManager.Logger = Logger;
+
+        // Initialize Foldables mod compatibility detection
+        FoldablesCompatibility.Initialize(Logger);
 
         Settings.BindSettings(Config);
 

--- a/SortingStrategy/ItemTypes.cs
+++ b/SortingStrategy/ItemTypes.cs
@@ -1,6 +1,6 @@
-﻿using EFT.InventoryLogic;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using EFT.InventoryLogic;
 
 namespace StashManagementHelper.SortingStrategy;
 

--- a/SortingStrategy/SortingStrategy.cs
+++ b/SortingStrategy/SortingStrategy.cs
@@ -16,7 +16,8 @@ public static class SortingStrategy
     private static DateTime lastConfigFileWriteTime = DateTime.MinValue;
     private static readonly string configPath;
 
-    private static List<string> SortOrder { get; set; } = new List<string> { "ContainerSize", "CellSize", "ItemType", "Weight", "Value", "FleaValue" };
+    // TODO: "FleaValue" removed - not ready for release
+    private static List<string> SortOrder { get; set; } = new List<string> { "ContainerSize", "CellSize", "ItemType", "Weight", "Value" };
 
     private static List<ItemTypes.ItemType> ItemTypeOrder { get; set; } =
     [
@@ -67,10 +68,11 @@ public static class SortingStrategy
     {
         LoadSortOrder();
 
-        if (SortOrder.Contains("FleaValue") && Settings.GetSortOption("FleaValue").HasFlag(SortOptions.Enabled))
-        {
-            FleaMarketHelper.StartCachingPricesForItems(items);
-        }
+        // TODO: Flea market sorting not ready yet
+        // if (SortOrder.Contains("FleaValue") && Settings.GetSortOption("FleaValue").HasFlag(SortOptions.Enabled))
+        // {
+        //     FleaMarketHelper.StartCachingPricesForItems(items);
+        // }
 
         if (SortOrder.Contains("Value") && Settings.GetSortOption("Value").HasFlag(SortOptions.Enabled))
         {
@@ -108,8 +110,9 @@ public static class SortingStrategy
             "CellSize" => item => item.CalculateCellSize().Length,
             "Weight" => item => item.TotalWeight,
             "Value" => item => GetItemValue(item),
-            "FleaValue" => item => FleaMarketHelper.GetItemFleaPrice(item),
-            _ => throw new ArgumentException($"Invalid sort type '{sortType}'")
+            // TODO: Flea market sorting not ready yet
+            // "FleaValue" => item => FleaMarketHelper.GetItemFleaPrice(item),
+            _ => _ => 0
         };
     }
 

--- a/StashManagementHelper.csproj
+++ b/StashManagementHelper.csproj
@@ -6,14 +6,14 @@
 		<Description>Stash Management Helper</Description>
 		<Version>0.2.0</Version>
 		<LangVersion>latest</LangVersion>
+		<BepInExPluginGuid>com.markosz.stashmanagementhelper</BepInExPluginGuid>
+		<BepInExPluginName>Markosz-StashManagementHelper</BepInExPluginName>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
 		<PackageReference Include="BepInEx.Core" Version="5.*" />
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-		<BepInExPluginGuid>com.markosz.stashmanagementhelper</BepInExPluginGuid>
-		<BepInExPluginName>Markosz-StashManagementHelper</BepInExPluginName>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
@@ -52,7 +52,7 @@
 		<Reference Include="Comfort">
 			<Private>False</Private>
 			<HintPath>$(ManagedAssembliesPath)\Comfort.dll</HintPath>
-		</Reference>	
+		</Reference>
 		<Reference Include="Newtonsoft.Json">
 			<HintPath>$(ManagedAssembliesPath)\Newtonsoft.Json.dll</HintPath>
 			<Private>False</Private>
@@ -68,15 +68,15 @@
 		<Reference Include="Sirenix.Serialization">
 			<Private>False</Private>
 			<HintPath>$(ManagedAssembliesPath)\Sirenix.Serialization.dll</HintPath>
-		</Reference>		
+		</Reference>
 		<Reference Include="UnityEngine.UI">
 			<HintPath>$(ManagedAssembliesPath)\UnityEngine.UI.dll</HintPath>
 			<Private>False</Private>
-		</Reference>	
+		</Reference>
 		<Reference Include="UnityEngine.UIModule">
 			<HintPath>$(ManagedAssembliesPath)\UnityEngine.UIModule.dll</HintPath>
 			<Private>False</Private>
-		</Reference>		
+		</Reference>
 		<Reference Include="UnityEngine.TextRenderingModule">
 			<HintPath>$(ManagedAssembliesPath)\UnityEngine.TextRenderingModule.dll</HintPath>
 			<Private>False</Private>

--- a/StashManagementHelper.csproj
+++ b/StashManagementHelper.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<AssemblyName>StashManagementHelper</AssemblyName>
 		<Description>Stash Management Helper</Description>
-		<Version>0.2.0</Version>
+		<Version>0.2.1</Version>
 		<LangVersion>latest</LangVersion>
 		<BepInExPluginGuid>com.markosz.stashmanagementhelper</BepInExPluginGuid>
 		<BepInExPluginName>Markosz-StashManagementHelper</BepInExPluginName>


### PR DESCRIPTION
- Fix infinite loop when fetching item values sometimes.
- Added Foldables mod compatibility, with the mod installed you can see a new option to enable or disable folding of backpacks and rigs with items inside. Disabled by default.
- Disabled 'Sort by Flea Market' option (accidentally left inside, wasn't in a good state).